### PR TITLE
Rename batch norm parameters for clarity

### DIFF
--- a/pytensor_ml/layers.py
+++ b/pytensor_ml/layers.py
@@ -125,8 +125,8 @@ class BatchNorm2D(Layer):
         self.affine = affine
         self.track_running_stats = track_running_stats
 
-        self.beta = None
-        self.gamma = None
+        self.loc = None
+        self.scale = None
 
         self.running_mean = None
         self.running_var = None
@@ -139,8 +139,8 @@ class BatchNorm2D(Layer):
             return
 
         if self.n_in is None and X is None:
-            self.gamma = None
-            self.beta = None
+            self.scale = None
+            self.loc = None
             return
 
         if X is not None:
@@ -149,8 +149,8 @@ class BatchNorm2D(Layer):
             n_in = self.n_in
 
         if self.affine:
-            self.gamma = pt.tensor(f"{self.name}_gamma", shape=(n_in,))
-            self.beta = pt.tensor(f"{self.name}_beta", shape=(n_in,))
+            self.scale = pt.tensor(f"{self.name}_scale", shape=(n_in,))
+            self.loc = pt.tensor(f"{self.name}_loc", shape=(n_in,))
             self.initialized = True
 
         else:
@@ -168,8 +168,8 @@ class BatchNorm2D(Layer):
         X_normalized = (X - mu) / pt.sqrt(sigma_sq + self.epsilon)
 
         if self.affine:
-            X_rescaled = X_normalized * self.gamma + self.beta
-            inputs.extend([self.gamma, self.beta])
+            X_rescaled = X_normalized * self.scale + self.loc
+            inputs.extend([self.loc, self.scale])
 
         else:
             X_rescaled = X_normalized

--- a/pytensor_ml/rewriting/layers.py
+++ b/pytensor_ml/rewriting/layers.py
@@ -58,13 +58,13 @@ def rewrite_batch_stats_to_running_average_stats(
     X_normalized: Variable
 
     """
-    X, gamma, beta, running_mean, running_var = node.inputs
+    X, loc, scale, running_mean, running_var = node.inputs
 
     res = (X - running_mean) / pt.sqrt(running_var + node.op.epsilon)
-    res = res * gamma + beta
+    res = loc + res * scale
 
     batch_norm_op = PredictionBatchNormLayer(
-        inputs=[X, gamma, beta, running_mean, running_var],
+        inputs=[X, loc, scale, running_mean, running_var],
         outputs=[res],
         name=f"{node.op.name}",
         n_in=node.op.n_in,
@@ -73,7 +73,7 @@ def rewrite_batch_stats_to_running_average_stats(
         affine=node.op.affine,
     )
 
-    X_normalized = batch_norm_op(X, gamma, beta, running_mean, running_var)
+    X_normalized = batch_norm_op(X, loc, scale, running_mean, running_var)
 
     return [X_normalized, None, None]
 


### PR DESCRIPTION
`gamma` and `beta` are used by Pytorch, but these names are just horrible. This PR renames them to `loc` and `scale`, which is more obvious.